### PR TITLE
C5gopen devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 2.8.3)
 
 project(cnr_logger)
 
@@ -11,20 +11,34 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 
 # Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+if(NOT CMAKE_CXX_STANDARD)  
+  #To compile with CMAKE 2.8.3 it is necessary to use C++11
+  #CMAKE_CXX_STANDARD is not available in CMAKE 2.8.3
+  #set(CMAKE_CXX_STANDARD 14) 
+  set(CMAKE_CXX_FLAGS "-std=c++11")
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(ROS_DISABLED "ROS ENABLED" OFF)
+option(ROS_DISABLED "ROS ENABLED" ON)
 
 if(ROS_DISABLED)
+  MESSAGE("***** ROS Disabled *****")
+  
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-  find_package(yaml-cpp REQUIRED)
+  
+  #In Ubuntu 14.04 find_package for yaml-cpp fails, the patch below fix the problem  
+  #find_package(yaml-cpp REQUIRED)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(yaml_cpp REQUIRED yaml-cpp)  
+
   find_package(Log4cxx)
-  add_compile_definitions(ROS_NOT_AVAILABLE)
+
+  #The fucntion add_compile_definitions is not available in CMAKE 2.8.3
+  #add_compile_definitions(ROS_NOT_AVAILABLE)
+  add_definitions(-DROS_NOT_AVAILABLE)
+  
   set(CNR_LOGGER_TARGET_LINK_LIBRARIES ${YAML_CPP_LIBRARIES} ${Log4cxx_LIBRARY})
   include_directories( include ${YAML_CPP_INCLUDE_DIRS} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ option(ROS_DISABLED "ROS ENABLED" ON)
 
 if(ROS_DISABLED)
   MESSAGE("***** ROS Disabled *****")
-  
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
   
   #In Ubuntu 14.04 find_package for yaml-cpp fails, the patch below fix the problem  
@@ -35,11 +34,11 @@ if(ROS_DISABLED)
 
   find_package(Log4cxx)
 
-  #The fucntion add_compile_definitions is not available in CMAKE 2.8.3
+  #The fucntion add_compile_definitions 
   #add_compile_definitions(ROS_NOT_AVAILABLE)
   add_definitions(-DROS_NOT_AVAILABLE)
   
-  set(CNR_LOGGER_TARGET_LINK_LIBRARIES ${YAML_CPP_LIBRARIES} ${Log4cxx_LIBRARY})
+  set(CNR_LOGGER_TARGET_LINK_LIBRARIES yaml-cpp log4cxx) #This variables are empty ${YAML_CPP_LIBRARIES} ${Log4cxx_LIBRARIES})
   include_directories( include ${YAML_CPP_INCLUDE_DIRS} )
 
   set(CNR_LOGGER_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/include")
@@ -68,7 +67,7 @@ if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
   APPEND_COVERAGE_COMPILER_FLAGS()
 endif()
 
-add_library(${PROJECT_NAME} src/${PROJECT_NAME}/cnr_logger.cpp )
+add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}/cnr_logger.cpp ) #to avoid the linking of yaml-cpp and log4cxx in the user program
 target_link_libraries( ${PROJECT_NAME} ${CNR_LOGGER_TARGET_LINK_LIBRARIES})
 target_compile_options(${PROJECT_NAME}
   PUBLIC $<$<CONFIG:Release>:-Ofast -funroll-loops -ffast-math >)
@@ -109,11 +108,21 @@ endif()
 
 
 ## Mark cpp header files for installation
+if(ROS_DISABLED)
+ #To keep compatibility of the include policy of ROS 
+ install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CNR_LOGGER_INSTALL_INCLUDE_DIR}/${PROJECT_NAME}
+   FILES_MATCHING PATTERN "*.h"
+   PATTERN ".git" EXCLUDE
+ )
+else()
  install(DIRECTORY include/${PROJECT_NAME}/
    DESTINATION ${CNR_LOGGER_INSTALL_INCLUDE_DIR}
    FILES_MATCHING PATTERN "*.h"
    PATTERN ".git" EXCLUDE
  )
+endif()
+
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CNR_LOGGER_INSTALL_LIB_DIR}

--- a/include/cnr_logger/cnr_logger.h
+++ b/include/cnr_logger/cnr_logger.h
@@ -82,6 +82,7 @@ public:
   /**
    * @brief TraceLogger. The constructor does not initilize the class. The function init() must be called afterwards.
    */
+  //TraceLogger();
   explicit TraceLogger();
   /**
    * @brief TraceLogger: The constructor fully initilize the class.

--- a/include/cnr_logger/cnr_logger.h
+++ b/include/cnr_logger/cnr_logger.h
@@ -82,7 +82,6 @@ public:
   /**
    * @brief TraceLogger. The constructor does not initilize the class. The function init() must be called afterwards.
    */
-  //TraceLogger();
   explicit TraceLogger();
   /**
    * @brief TraceLogger: The constructor fully initilize the class.

--- a/src/cnr_logger/cnr_logger.cpp
+++ b/src/cnr_logger/cnr_logger.cpp
@@ -189,9 +189,7 @@ TraceLogger::TraceLogger()
 
 TraceLogger::TraceLogger(const std::string& logger_id, const std::string& path,
                          const bool star_header, const bool default_values)
-  : TraceLogger()
-{
-  try
+  : logger_id_(""), path_(""), default_values_(false), initialized_(false) // TraceLogger() Enrico 03/12/2021 the compiler can't find the TraceLogger() constructor
   {
     if(!init(logger_id, path, star_header, default_values))
     {

--- a/src/cnr_logger/cnr_logger.cpp
+++ b/src/cnr_logger/cnr_logger.cpp
@@ -190,6 +190,8 @@ TraceLogger::TraceLogger()
 TraceLogger::TraceLogger(const std::string& logger_id, const std::string& path,
                          const bool star_header, const bool default_values)
   : logger_id_(""), path_(""), default_values_(false), initialized_(false) // TraceLogger() Enrico 03/12/2021 the compiler can't find the TraceLogger() constructor
+{
+  try
   {
     if(!init(logger_id, path, star_header, default_values))
     {

--- a/src/cnr_logger/cnr_logger.cpp
+++ b/src/cnr_logger/cnr_logger.cpp
@@ -214,7 +214,6 @@ bool TraceLogger::check(const std::string& path)
   bool res = true;
 #if defined(ROS_NOT_AVAILABLE)
   YAML::Node config = YAML::LoadFile(path);
-
   res &= (config["appenders"] && config["appenders"].IsSequence());
   res &= (config["levels"]?config["levels"].IsSequence():true);
   res &= (config["pattern_layout"]?config["pattern_layout"].IsScalar():true);


### PR DESCRIPTION
To get the compatibility with Ubuntu 14.04 (CMake 2.8.3) + some improvements to compile cnr_logger without catkin. I left comments in CMakeFiles as a reminder of the modifications.