### PR TITLE
build_type fixed in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,8 @@
   <author email="nicola.pedrocchi@stiima.cnr.it">Nicola Pedrocchi</author>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == ''">cmake</buildtool_depend>
   
   <build_depend>boost</build_depend>
   <build_depend>log4cxx</build_depend>
@@ -26,6 +27,7 @@
   
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
-    <build_type condition="$ROS_VERSION == 2">cmake</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <build_type condition="$ROS_VERSION == ''">cmake</build_type>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,7 @@
   <author email="nicola.pedrocchi@stiima.cnr.it">Nicola Pedrocchi</author>
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
-  <buildtool_depend condition="$ROS_VERSION == ''">cmake</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION != 1">cmake</buildtool_depend>
   
   <build_depend>boost</build_depend>
   <build_depend>log4cxx</build_depend>
@@ -27,7 +26,6 @@
   
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
-    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
-    <build_type condition="$ROS_VERSION == ''">cmake</build_type>
+    <build_type condition="$ROS_VERSION != 1">cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
If ROS_VERSION is NOT 1 use cmake instead of catkin. Previously cmake was set if and only if ROS_VERSION == 2